### PR TITLE
Remove double spaces when array contains null

### DIFF
--- a/timber-acf-wp-blocks.php
+++ b/timber-acf-wp-blocks.php
@@ -147,7 +147,9 @@ function timber_blocks_callback( $block, $content = '', $is_preview = false, $po
 		'align' . $context['block']['align'],
 	];
 
-	$context['classes'] = implode( ' ', $classes );
+	$context['classes'] = implode( ' ', array_filter( $classes, function ( $class ) {
+		return ! is_null( $class );
+	} ) );
 
 	$context = apply_filters( 'timber/acf-gutenberg-blocks-data/' . $slug, $context );
 	$context = apply_filters( 'timber/acf-gutenberg-blocks-data/' . $block['id'], $context );


### PR DESCRIPTION
When `$block['className']` or `$is_preview` isn't set the array contains null which when using implode becomes a space. This results in having classes like `testimonial  align` instead `testimonial align`. It's a detail, but this is how I like ;)

Great work btw! 🙏